### PR TITLE
Add loading attributes to images

### DIFF
--- a/sections/background-video.liquid
+++ b/sections/background-video.liquid
@@ -77,7 +77,7 @@
             {% if section.settings.image %} style="background-position: {{ section.settings.image.presentation.focal_point }}"{% endif %}>
           <noscript>
             <div class="rimage-wrapper" style="padding-top:{{ 1 | divided_by: cover_image.aspect_ratio | times: 100 }}%">
-              <img src="{{ cover_image | img_url: '1024x1024' }}" alt="{{ cover_image.alt | escape }}" class="rimage__image">
+                <img src="{{ cover_image | img_url: '1024x1024' }}" alt="{{ cover_image.alt | escape }}" class="rimage__image" loading="eager" fetchpriority="high">
             </div>
           </noscript>
         </div>

--- a/sections/slideshow.liquid
+++ b/sections/slideshow.liquid
@@ -78,7 +78,7 @@
             {%- endif -%}
               <noscript>
                 <div class="rimage-wrapper" style="padding-top:{{ 1 | divided_by: block.settings.image.aspect_ratio | times: 100 }}%">
-                  <img src="{{ block.settings.image | img_url: '1024x1024' }}" alt="{{ block.settings.image.alt | escape }}" class="rimage__image"/>
+                    <img src="{{ block.settings.image | img_url: '1024x1024' }}" alt="{{ block.settings.image.alt | escape }}" class="rimage__image" loading="eager" fetchpriority="high"/>
                 </div>
               </noscript>
           </div>
@@ -94,7 +94,7 @@
               {%- endif -%}
                 <noscript>
                   <div class="rimage-wrapper" style="padding-top:{{ 1 | divided_by: block.settings.mobile_image.aspect_ratio | times: 100 }}%">
-                    <img src="{{ block.settings.mobile_image | img_url: '1024x1024' }}" alt="{{ block.settings.mobile_image.alt | escape }}" class="rimage__image"/>
+                      <img src="{{ block.settings.mobile_image | img_url: '1024x1024' }}" alt="{{ block.settings.mobile_image.alt | escape }}" class="rimage__image" loading="eager" fetchpriority="high"/>
                   </div>
                 </noscript>
             </div>

--- a/snippets/responsive-image.liquid
+++ b/snippets/responsive-image.liquid
@@ -13,7 +13,7 @@
 >
   <div class="rimage-wrapper lazyload--placeholder" style="padding-top:{{ 1 | divided_by: aspect_ratio | times: 100 }}%">
     {% if initial %}
-      <img class="rimage__image lazyload fade-in {% if cover %}cover{% endif %}" data-src="{{ image | img_url: initial }}" alt="{{ image.alt | escape }}">
+      <img class="rimage__image lazyload fade-in {% if cover %}cover{% endif %}" data-src="{{ image | img_url: initial }}" alt="{{ image.alt | escape }}" loading="lazy" fetchpriority="low">
       {% assign initial = false %}
     {% endif %}
     {% assign img_url = image | img_url: '1x1' | replace: '_1x1.', '_{width}x.' %}
@@ -26,11 +26,12 @@
       width="{{ image.width }}"
       height="{{ image.height }}"
       {% if cover %}data-parent-fit="cover"{% endif %}
-      {% if image.presentation %}style="object-position: {{ image.presentation.focal_point }}"{% endif %}>
+      {% if image.presentation %}style="object-position: {{ image.presentation.focal_point }}"{% endif %}
+      loading="lazy" fetchpriority="low">
 
     <noscript>
       {% assign img_url = image | img_url: '1024x1024' %}
-      <img src="{{ img_url }}" alt="{{ image.alt | escape }}" class="rimage__image">
+      <img src="{{ img_url }}" alt="{{ image.alt | escape }}" class="rimage__image" loading="lazy" fetchpriority="low">
     </noscript>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- set `loading="lazy"` and `fetchpriority="low"` on snippet images
- eagerly load hero images in slideshow and background video sections

## Testing
- `tidy -errors -q snippets/responsive-image.liquid`
- `tidy -errors -q sections/slideshow.liquid`
- `tidy -errors -q sections/background-video.liquid`


------
https://chatgpt.com/codex/tasks/task_e_68429b280ee4832bb5229e4b00911bd2