### PR TITLE
Add lazy/eager loading attributes

### DIFF
--- a/sections/Homepage-category-slider.liquid
+++ b/sections/Homepage-category-slider.liquid
@@ -9,7 +9,7 @@
         <a href="{{ link_url }}">
           <div class="icon-circle">
             {% if block.settings.icon %}
-              <img src="{{ block.settings.icon | img_url: '100x100' }}" alt="{{ label }}">
+              <img src="{{ block.settings.icon | img_url: '100x100' }}" alt="{{ label }}" loading="lazy">
             {% endif %}
           </div>
           <p class="slide-label">

--- a/sections/collection-slider.liquid
+++ b/sections/collection-slider.liquid
@@ -8,7 +8,7 @@
         <a href="{{ link_url }}">
           <div class="icon-circle">
             {% if block.settings.icon %}
-              <img src="{{ block.settings.icon | img_url: '100x100' }}" alt="{{ label }}">
+              <img src="{{ block.settings.icon | img_url: '100x100' }}" alt="{{ label }}" loading="lazy">
             {% endif %}
           </div>
           <p class="slide-label">

--- a/sections/featured-product.liquid
+++ b/sections/featured-product.liquid
@@ -825,7 +825,7 @@
                         <div class="product-detail__trust-img" style="height: {{ block.settings.icon_size }}px;width: {{ block.settings.icon_size }}px;">
                           {% if block.settings.image1 %}
                             {%- assign image_width = block.settings.icon_size | times: 2 | append: "x" -%}
-                            <img class="cc-icon" src="{{ block.settings.image1 | img_url: image_width }}" alt="{{ block.settings.image1.alt }}" width="{{ block.settings.icon_size }}"/>
+                            <img class="cc-icon" src="{{ block.settings.image1 | img_url: image_width }}" alt="{{ block.settings.image1.alt }}" width="{{ block.settings.icon_size }}" loading="lazy"/>
                           {% else %}
                             {% render 'icon', icon: block.settings.icon1, width: block.settings.icon_size %}
                           {% endif %}
@@ -844,7 +844,7 @@
                         <div class="product-detail__trust-img" style="height: {{ block.settings.icon_size }}px;width: {{ block.settings.icon_size }}px;">
                           {% if block.settings.image2 %}
                             {%- assign image_width = block.settings.icon_size | times: 2 | append: "x" -%}
-                            <img class="cc-icon" src="{{ block.settings.image2 | img_url: image_width }}" alt="{{ block.settings.image2.alt }}" width="{{ block.settings.icon_size }}"/>
+                            <img class="cc-icon" src="{{ block.settings.image2 | img_url: image_width }}" alt="{{ block.settings.image2.alt }}" width="{{ block.settings.icon_size }}" loading="lazy"/>
                           {% else %}
                             {% render 'icon', icon: block.settings.icon2, width: block.settings.icon_size %}
                           {% endif %}
@@ -863,7 +863,7 @@
                         <div class="product-detail__trust-img" style="height: {{ block.settings.icon_size }}px;width: {{ block.settings.icon_size }}px;">
                           {% if block.settings.image3 %}
                             {%- assign image_width = block.settings.icon_size | times: 2 | append: "x" -%}
-                            <img class="cc-icon" src="{{ block.settings.image3 | img_url: image_width }}" alt="{{ block.settings.image3.alt }}" width="{{ block.settings.icon_size }}"/>
+                            <img class="cc-icon" src="{{ block.settings.image3 | img_url: image_width }}" alt="{{ block.settings.image3.alt }}" width="{{ block.settings.icon_size }}" loading="lazy"/>
                           {% else %}
                             {% render 'icon', icon: block.settings.icon3, width: block.settings.icon_size %}
                           {% endif %}
@@ -882,7 +882,7 @@
                         <div class="product-detail__trust-img" style="height: {{ block.settings.icon_size }}px;width: {{ block.settings.icon_size }}px;">
                           {% if block.settings.image4 %}
                             {%- assign image_width = block.settings.icon_size | times: 2 | append: "x" -%}
-                            <img class="cc-icon" src="{{ block.settings.image4 | img_url: image_width }}" alt="{{ block.settings.image4.alt }}" width="{{ block.settings.icon_size }}"/>
+                            <img class="cc-icon" src="{{ block.settings.image4 | img_url: image_width }}" alt="{{ block.settings.image4.alt }}" width="{{ block.settings.icon_size }}" loading="lazy"/>
                           {% else %}
                             {% render 'icon', icon: block.settings.icon4, width: block.settings.icon_size %}
                           {% endif %}

--- a/sections/footer.liquid
+++ b/sections/footer.liquid
@@ -79,7 +79,7 @@
                   {%- capture double_image_width -%}{{ block.settings.image_width | times: 2 }}x{%- endcapture -%}
                   <div class="rimage-outer-wrapper" style="width: {{ block.settings.image_width }}px">
                     <div class="rimage-wrapper lazyload--placeholder" style="padding-top:{{ 1 | divided_by: block.settings.image.aspect_ratio | times: 100 }}%">
-                      <img class="rimage__image lazyload fade-in" data-src="{{ block.settings.image | img_url: double_image_width }}" alt="{{ shop.name | escape }}" />
+                      <img class="rimage__image lazyload fade-in" data-src="{{ block.settings.image | img_url: double_image_width }}" alt="{{ shop.name | escape }}" loading="lazy" />
                     </div>
                   </div>
                 </div>
@@ -236,7 +236,7 @@
                    alt="{{ section.settings.custom_payment_icon.alt }}"
                    width="{{ section.settings.custom_payment_icon.width }}"
                    height="{{ section.settings.custom_payment_icon.height }}"
-              />
+                   loading="lazy" />
             {% endif %}
           </div>
 

--- a/sections/header.liquid
+++ b/sections/header.liquid
@@ -232,7 +232,7 @@
       {% if section.settings.logo != blank %}
         {% assign double_logo_width = section.settings.logo_width | default: 250 | times: 2 %}
         {% capture img_size %}{% if double_logo_width > 2048 %}2048{% else %}{{ double_logo_width }}{% endif %}x{% endcapture %}
-        <img src="{{ section.settings.logo | img_url: img_size }}" alt="{{ shop.name | escape }}" itemprop="logo" />
+        <img src="{{ section.settings.logo | img_url: img_size }}" alt="{{ shop.name | escape }}" itemprop="logo" loading="eager" fetchpriority="high" />
       {% else %}
         {{ shop.name | escape }}
       {% endif %}
@@ -255,12 +255,12 @@
       {% assign double_logo_width = section.settings.logo_width | default: 250 | times: 2 %}
       {% capture img_size %}{% if double_logo_width > 2048 %}2048{% else %}{{ double_logo_width }}{% endif %}x{% endcapture %}
       <img src="{{ section.settings.logo | img_url: img_size }}" alt="{{ shop.name | escape }}" itemprop="logo"
-           width="{{ section.settings.logo.width }}" height="{{ section.settings.logo.height }}"/>
+           width="{{ section.settings.logo.width }}" height="{{ section.settings.logo.height }}" loading="eager" fetchpriority="high"/>
 
       {% if section.settings.alt_logo != blank %}
       <span class="alt-logo">
         <img src="{{ section.settings.alt_logo | img_url: img_size }}" alt="{{ shop.name | escape }}" itemprop="logo"
-             width="{{ section.settings.alt_logo.width }}" height="{{ section.settings.alt_logo.height }}"/>
+             width="{{ section.settings.alt_logo.width }}" height="{{ section.settings.alt_logo.height }}" loading="eager" fetchpriority="high"/>
       </span>
       {% endif %}
     {% else %}

--- a/sections/main-password.liquid
+++ b/sections/main-password.liquid
@@ -48,7 +48,7 @@
         {% if section.settings.logo != blank %}
           {% assign double_logo_width = section.settings.logo_width | default: 250 | times: 2 %}
           {% capture img_size %}{% if double_logo_width > 2048 %}2048{% else %}{{ double_logo_width }}{% endif %}x{% endcapture %}
-          <img src="{{ section.settings.logo | img_url: img_size }}" alt="{{ shop.name | escape }}" itemprop="logo" />
+          <img src="{{ section.settings.logo | img_url: img_size }}" alt="{{ shop.name | escape }}" itemprop="logo" loading="eager" fetchpriority="high" />
         {% else %}
           {{ shop.name | escape }}
         {% endif %}

--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -875,7 +875,7 @@
                         <div class="product-detail__trust-img" style="height: {{ block.settings.icon_size }}px;width: {{ block.settings.icon_size }}px;">
                           {% if block.settings.image1 %}
                             {%- assign image_width = block.settings.icon_size | times: 2 | append: "x" -%}
-                            <img class="cc-icon" src="{{ block.settings.image1 | img_url: image_width }}" alt="{{ block.settings.image1.alt }}" width="{{ block.settings.icon_size }}"/>
+                            <img class="cc-icon" src="{{ block.settings.image1 | img_url: image_width }}" alt="{{ block.settings.image1.alt }}" width="{{ block.settings.icon_size }}" loading="lazy"/>
                           {% else %}
                             {% render 'icon', icon: block.settings.icon1, width: block.settings.icon_size %}
                           {% endif %}
@@ -894,7 +894,7 @@
                         <div class="product-detail__trust-img" style="height: {{ block.settings.icon_size }}px;width: {{ block.settings.icon_size }}px;">
                           {% if block.settings.image2 %}
                             {%- assign image_width = block.settings.icon_size | times: 2 | append: "x" -%}
-                            <img class="cc-icon" src="{{ block.settings.image2 | img_url: image_width }}" alt="{{ block.settings.image2.alt }}" width="{{ block.settings.icon_size }}"/>
+                            <img class="cc-icon" src="{{ block.settings.image2 | img_url: image_width }}" alt="{{ block.settings.image2.alt }}" width="{{ block.settings.icon_size }}" loading="lazy"/>
                           {% else %}
                             {% render 'icon', icon: block.settings.icon2, width: block.settings.icon_size %}
                           {% endif %}
@@ -913,7 +913,7 @@
                         <div class="product-detail__trust-img" style="height: {{ block.settings.icon_size }}px;width: {{ block.settings.icon_size }}px;">
                           {% if block.settings.image3 %}
                             {%- assign image_width = block.settings.icon_size | times: 2 | append: "x" -%}
-                            <img class="cc-icon" src="{{ block.settings.image3 | img_url: image_width }}" alt="{{ block.settings.image3.alt }}" width="{{ block.settings.icon_size }}"/>
+                            <img class="cc-icon" src="{{ block.settings.image3 | img_url: image_width }}" alt="{{ block.settings.image3.alt }}" width="{{ block.settings.icon_size }}" loading="lazy"/>
                           {% else %}
                             {% render 'icon', icon: block.settings.icon3, width: block.settings.icon_size %}
                           {% endif %}
@@ -932,7 +932,7 @@
                         <div class="product-detail__trust-img" style="height: {{ block.settings.icon_size }}px;width: {{ block.settings.icon_size }}px;">
                           {% if block.settings.image4 %}
                             {%- assign image_width = block.settings.icon_size | times: 2 | append: "x" -%}
-                            <img class="cc-icon" src="{{ block.settings.image4 | img_url: image_width }}" alt="{{ block.settings.image4.alt }}" width="{{ block.settings.icon_size }}"/>
+                            <img class="cc-icon" src="{{ block.settings.image4 | img_url: image_width }}" alt="{{ block.settings.image4.alt }}" width="{{ block.settings.icon_size }}" loading="lazy"/>
                           {% else %}
                             {% render 'icon', icon: block.settings.icon4, width: block.settings.icon_size %}
                           {% endif %}

--- a/snippets/media.liquid
+++ b/snippets/media.liquid
@@ -10,9 +10,12 @@
       <div class="rimage-wrapper lazyload--placeholder"
            style="padding-top:{{ 1 | divided_by: media.preview_image.aspect_ratio | times: 100 | minus: 0.1 | round: 1 }}%">
         {% assign img_url = media.preview_image | img_url: '1x1' | replace: '_1x1.', '_{width}x.' %}
-        <img class="rimage__image lazyload--manual {% unless prevent_lazyload %}fade-in{% endunless %}"
+          <img class="rimage__image lazyload--manual {% unless prevent_lazyload %}fade-in{% endunless %}"
              {% if prevent_lazyload %}
                src="{{ media.preview_image | img_url: '360x' }}"
+               loading="eager" fetchpriority="high"
+             {% else %}
+               loading="lazy"
              {% endif %}
              data-src="{{ img_url }}"
              data-widths="[460, 540, 720, 900, 1080, 1296, 1512, 1728, 2048]"

--- a/snippets/responsive-image.liquid
+++ b/snippets/responsive-image.liquid
@@ -6,6 +6,7 @@
     assign cover = false
   endif
   assign aspect_ratio = aspect_ratio | at_least: min_aspect_ratio
+  assign image_loading = loading | default: "lazy"
 -%}
 
 <div class="rimage-outer-wrapper" style="max-width: {{ image.width }}px"
@@ -13,7 +14,7 @@
 >
   <div class="rimage-wrapper lazyload--placeholder" style="padding-top:{{ 1 | divided_by: aspect_ratio | times: 100 }}%">
     {% if initial %}
-      <img class="rimage__image lazyload fade-in {% if cover %}cover{% endif %}" data-src="{{ image | img_url: initial }}" alt="{{ image.alt | escape }}">
+      <img class="rimage__image lazyload fade-in {% if cover %}cover{% endif %}" data-src="{{ image | img_url: initial }}" alt="{{ image.alt | escape }}" loading="{{ image_loading }}" {% if image_loading == 'eager' %}fetchpriority="high"{% endif %}>
       {% assign initial = false %}
     {% endif %}
     {% assign img_url = image | img_url: '1x1' | replace: '_1x1.', '_{width}x.' %}
@@ -25,6 +26,7 @@
       alt="{{ image.alt | escape }}"
       width="{{ image.width }}"
       height="{{ image.height }}"
+      loading="{{ image_loading }}" {% if image_loading == 'eager' %}fetchpriority="high"{% endif %}
       {% if cover %}data-parent-fit="cover"{% endif %}
       {% if image.presentation %}style="object-position: {{ image.presentation.focal_point }}"{% endif %}>
 

--- a/snippets/social-icons.liquid
+++ b/snippets/social-icons.liquid
@@ -56,7 +56,7 @@
       {% if settings.social_custom_url != blank %}
         <li>
           <a aria-label="{{ icon_setting.alt | escape }}" class="social-custom" target="_blank" rel="noopener" href="{{ settings.social_custom_url }}">
-            <img src="{{ icon_setting | img_url: icon_size }}" alt="{{ icon_setting.alt }}" width="{{ icon_setting.width }}" height="{{ icon_setting.height }}"/>
+            <img src="{{ icon_setting | img_url: icon_size }}" alt="{{ icon_setting.alt }}" width="{{ icon_setting.width }}" height="{{ icon_setting.height }}" loading="lazy"/>
           </a>
         </li>
       {% endif %}

--- a/snippets/split_images_from_content.liquid
+++ b/snippets/split_images_from_content.liquid
@@ -14,7 +14,7 @@ Use:
         {% assign src = split_content | split: 'src="' %}
         {% assign src = src[1] | split: '"' | first | replace: '//cdn', 'http://cdn' | replace: 'http:http://', 'http://' %}
         {% if src %}
-            {% capture split_images %}{{ split_images }}<div class="split-image"><img src="{{ src }}" alt="{{ article.title }}" /></div>{% endcapture %}
+            {% capture split_images %}{{ split_images }}<div class="split-image"><img src="{{ src }}" alt="{{ article.title }}" loading="lazy" /></div>{% endcapture %}
         {% endif %}
     {% endif %}
     {% assign split_content = split_content | replace_first: '<img ', '<meta ' | replace_first: ' src="', ' srcX="' %}


### PR DESCRIPTION
## Summary
- add optional image loading logic to `responsive-image`
- allow eager loading for hero media via `media` snippet
- mark main logos and icons for eager loading
- lazy load non-critical images across various sections

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6842aa33fc00832ba50212343a2e866a